### PR TITLE
Add timezone support to CalDAV event creation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "n8n-caldav-node",
-  "version": "1.0.3",
+  "name": "n8n-nodes-caldav-calendar",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "n8n-caldav-node",
-      "version": "1.0.3",
+      "name": "n8n-nodes-caldav-calendar",
+      "version": "2.0.3",
       "license": "MIT",
       "dependencies": {
         "dav": "^1.8.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-caldav-calendar",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "n8n community node for CalDAV calendar integration",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
This commit fixes the timezone issue where events were always created in UTC+0 regardless of the timezone settings in n8n.

Changes:
- Added a new 'Timezone' parameter to the createEvent operation that allows users to select from 40+ common timezones
- Created formatDateForICalLocal() function to format dates without timezone conversion
- Created generateVTimezone() function to generate proper VTIMEZONE blocks for iCal format
- Updated generateICalEvent() to include VTIMEZONE data and use DTSTART;TZID format for non-UTC timezones
- Modified the createEvent operation to read and pass the timezone parameter
- Added comprehensive timezone definitions for Europe, Americas, Asia, Australia, and Pacific regions
- Events now properly respect the selected timezone instead of always defaulting to UTC

The implementation follows the iCalendar RFC 5545 standard for timezone handling, including proper VTIMEZONE blocks with STANDARD and DAYLIGHT components where applicable.

Default timezone is UTC to maintain backward compatibility. Users can now select their desired timezone from the dropdown, and events will be created with the correct local time in that timezone.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds timezone selection and proper iCal VTIMEZONE handling to CalDAV event creation.
> 
> - **CalDAV Node (`nodes/Caldav/Caldav.node.ts`)**:
>   - Add `timezone` option to `createEvent` with a curated list of common IANA timezones.
>   - Implement `formatDateForICalLocal()` and `generateVTimezone()`; add `CALSCALE:GREGORIAN` and embed `VTIMEZONE` when not `UTC`.
>   - Update `generateICalEvent()` to output `DTSTART/DTEND` as UTC (`Z`) or local with `TZID=...`; pass the selected `timezone`; improve create logs to include timezone.
> - **Package**:
>   - Bump version to `2.1.0` and update package metadata.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5339c1cf3d773490afc702556c9e8fcb854dfcc4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->