### PR TITLE
fix(parser): support iCalendar property parameters on text properties

### DIFF
--- a/nodes/Caldav/Caldav.node.ts
+++ b/nodes/Caldav/Caldav.node.ts
@@ -536,7 +536,7 @@ export class Caldav implements INodeType {
 					if (!obj.calendarData) continue;
 					
 					const calendarData = obj.calendarData;
-					const uidMatch = calendarData.match(/UID:([^\r\n]+)/);
+					const uidMatch = calendarData.match(/UID(?:;[^:]*)?:([^\r\n]+)/);
 					
 					if (uidMatch && uidMatch[1].trim() === uid) {
 						// Проверяем и исправляем URL события если необходимо
@@ -1361,7 +1361,7 @@ export class Caldav implements INodeType {
 									}
 									
 									// Проверяем правила повторения (RRULE)
-									const rruleMatch = eventData.match(/RRULE:([^\r\n]+)/);
+									const rruleMatch = eventData.match(/RRULE(?:;[^:]*)?:([^\r\n]+)/);
 									if (rruleMatch && isRecurringEventOnDate(eventDate, targetDate, rruleMatch[1], eventData)) {
 										// Для повторяющихся событий рассчитываем актуальные даты
 										// Парсим также DTEND для расчета продолжительности
@@ -1420,13 +1420,18 @@ export class Caldav implements INodeType {
 							}
 							
 							// Извлекаем основную информацию о событии
-							const summaryMatch = eventData.match(/SUMMARY:(.+)/);
-							const descriptionMatch = eventData.match(/DESCRIPTION:(.+)/);
+							// RFC 5545 §3.5: any property may carry parameters between
+							// the property name and the value separator (e.g. Outlook /
+							// Exchange emit `SUMMARY;LANGUAGE=de-DE:...`). The non-
+							// capturing `(?:;[^:]*)?` swallows them so `:(.+)` lands on
+							// the value. Mirrors the existing DTSTART pattern.
+							const summaryMatch = eventData.match(/SUMMARY(?:;[^:]*)?:(.+)/);
+							const descriptionMatch = eventData.match(/DESCRIPTION(?:;[^:]*)?:(.+)/);
 							const dtStartMatch = eventData.match(/DTSTART[^:]*:(.+)/);
 							const dtEndMatch = eventData.match(/DTEND[^:]*:(.+)/);
-							const uidMatch = eventData.match(/UID:(.+)/);
-							const locationMatch = eventData.match(/LOCATION:(.+)/);
-							const webUrlMatch = eventData.match(/URL:(.+)/);
+							const uidMatch = eventData.match(/UID(?:;[^:]*)?:(.+)/);
+							const locationMatch = eventData.match(/LOCATION(?:;[^:]*)?:(.+)/);
+							const webUrlMatch = eventData.match(/URL(?:;[^:]*)?:(.+)/);
 
 							// Парсим даты для ISO формата
 							const dtStartRaw = dtStartMatch ? dtStartMatch[1].trim() : '';
@@ -1489,7 +1494,7 @@ export class Caldav implements INodeType {
 									
 									const eventData = 'BEGIN:VEVENT' + veventBlock.split('END:VEVENT')[0] + 'END:VEVENT';
 									const dtStartMatch = eventData.match(/DTSTART[^:]*:([^\r\n]+)/);
-									const summaryMatch = eventData.match(/SUMMARY:([^\r\n]+)/);
+									const summaryMatch = eventData.match(/SUMMARY(?:;[^:]*)?:([^\r\n]+)/);
 									
 									sampleEvents.push({
 										objectIndex: i,


### PR DESCRIPTION
## Problem

Outlook / Exchange CalDAV (anything that traverses Microsoft 365 / on-prem Exchange ActiveSync to a CalDAV bridge like Davical or Davis) always emits text properties with a parameter between the property name and the value separator, e.g.:

```
SUMMARY;LANGUAGE=de-DE:Sprint Review
DESCRIPTION;LANGUAGE=de-DE:Demo neuer Features
LOCATION;LANGUAGE=de-DE:Besprechungsraum 29
```

This is fully RFC 5545 §3.5 conformant — any property may carry parameters. The current regexes only match the bare form and silently fail on every parameterised variant, so the node returns empty `summary` / `description` / `location` for any Outlook-sourced calendar.

## Fix

Eight regexes updated to swallow optional parameters via `(?:;[^:]*)?:` — same idea as the existing `DTSTART[^:]*:` patterns already in the file:

| Line | Property | Path |
|---|---|---|
| 539 | `UID` | cross-account lookup |
| 1364 | `RRULE` | recurrence check |
| 1428 | `SUMMARY` | per-event extraction |
| 1429 | `DESCRIPTION` | per-event extraction |
| 1432 | `UID` | per-event extraction |
| 1433 | `LOCATION` | per-event extraction |
| 1434 | `URL` | per-event extraction |
| 1497 | `SUMMARY` | diagnostic preview |

No tests in the repo to extend (would have been happy to add some — let me know if you want that as a follow-up).

## Verification

End-to-end-tested against a live Outlook/Exchange-via-Davis CalDAV setup (our internal fork carries the same patch). Before: a workflow polling 8 events from an Outlook calendar returned all 8 with empty `summary`/`description`/`location`. After: all 8 events have the fields populated correctly. The non-parameterised path keeps working — calendars from non-Microsoft sources (Radicale, Nextcloud, iCloud, …) are unaffected by the change.

## Notes

- No version bump in `package.json` — leaving that decision to you.
- Existing PR #15 (tsdav migration) is unrelated and not touched here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to broadening a few iCalendar parsing regexes to accept optional RFC5545 parameters, with no changes to network calls or data persistence. Main risk is slightly more permissive matching could capture unintended lines if malformed iCal is encountered.
> 
> **Overview**
> Improves CalDAV iCalendar parsing to handle RFC5545 property parameters (e.g. `SUMMARY;LANGUAGE=...:`) that are commonly emitted by Outlook/Exchange.
> 
> Updates the regex extraction for `UID`, `RRULE`, `SUMMARY`, `DESCRIPTION`, `LOCATION`, and `URL` (including diagnostic previews) so event lookups, recurrence detection, and returned event fields no longer come back empty when parameters are present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41e25237c9fc3fccb847573bc3b704c82e4219cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->